### PR TITLE
Fix slider level typing and validation

### DIFF
--- a/src/components/Emotion.tsx
+++ b/src/components/Emotion.tsx
@@ -50,7 +50,7 @@ const Emotion = ({ emotionId, initialLevel = 3, onLevelChange }: Props) => {
 
     // 強制的に再レンダリング
     setLevel(newLevel);
-    setForceUpdate((prev) => prev + 1);
+    setForceUpdate((prev: number) => prev + 1);
 
     // 親コンポーネントに通知
     if (onLevelChange) {
@@ -69,7 +69,7 @@ const Emotion = ({ emotionId, initialLevel = 3, onLevelChange }: Props) => {
 
     // 強制的に再レンダリング
     setLevel(newLevel);
-    setForceUpdate((prev) => prev + 1);
+    setForceUpdate((prev: number) => prev + 1);
 
     if (onLevelChange) {
       onLevelChange(newLevel);
@@ -135,7 +135,7 @@ const Emotion = ({ emotionId, initialLevel = 3, onLevelChange }: Props) => {
                 className="flex flex-col items-center"
                 onClick={() => {
                   setLevel(num);
-                  setForceUpdate((prev) => prev + 1);
+                  setForceUpdate((prev: number) => prev + 1);
                   if (onLevelChange) onLevelChange(num);
                 }}
               >

--- a/src/pages/EmotionDetail.tsx
+++ b/src/pages/EmotionDetail.tsx
@@ -19,7 +19,9 @@ const EmotionDetail = () => {
     id: string;
     level: string;
   }>();
-  const [level, setLevel] = useState(parseInt(initialLevel));
+  const parsedLevel = parseInt(initialLevel);
+  const safeLevel = parsedLevel >= 1 && parsedLevel <= 5 ? parsedLevel : 3;
+  const [level, setLevel] = useState(safeLevel);
   const navigate = useNavigate();
   const emotion = emotions.find((e) => e.id === id);
   const [showThankYouModal, setShowThankYouModal] = useState(false);

--- a/src/utils/getUnicodeForEmotion.ts
+++ b/src/utils/getUnicodeForEmotion.ts
@@ -7,7 +7,7 @@ import { Emotion, emotionMap } from "../types/emotionMap";
  */
 export const getUnicodeForEmotion = (
   emotion: Emotion,
-  level: number // levelは使用しないが、互換性のために残す
+  _level: number // levelは使用しないが、互換性のために残す
 ): string => {
   // 該当する絵文字のUnicodeを取得
   const unicode = emotionMap[emotion].emoji;


### PR DESCRIPTION
## Summary
- validate the numeric level param when opening EmotionDetail
- annotate state update callbacks with explicit `number` types
- mark unused argument in emoji lookup helper

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6849648e8e588325b352d8464c3e7b3e